### PR TITLE
リリースノート自動作成機能を追加

### DIFF
--- a/.github/workflows/automatically_generated_release_notes.yml
+++ b/.github/workflows/automatically_generated_release_notes.yml
@@ -1,0 +1,17 @@
+# https://docs.github.com/ja/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    authors:
+      - github-actions
+    labels:
+      - ignore-for-release
+  categories:
+    - title: New Features 🎉
+      labels:
+        - "enhancement"
+    - title: Bug Fix 💊
+      labels:
+        - "bug"
+    - title: Other Changes 🛠
+      labels:
+        - "*"

--- a/.github/workflows/automatically_labeling_pr.yml
+++ b/.github/workflows/automatically_labeling_pr.yml
@@ -23,10 +23,8 @@ jobs:
             label_name=$(echo "enhancement")
           elif [ $branch_type == 'fix' ] || [ $branch_type == 'hotfix' ]; then
             label_name=$(echo "bug")
-          elif [ $branch_type == 'release' ]; then
-            label_name=$(echo "release")
           else
-            label_name=""
+            label_name=$(echo "ignore-for-release")
           fi
           echo "::set-output name=label_name::$label_name"
 


### PR DESCRIPTION
# issues (任意)

# 修正内容 (必須)

# capture (任意)

| before | after |
|:---|:---:|
|<img src="" width=320 /> |<img src="" width=320 /> |

# refs (任意)
https://docs.github.com/ja/repositories/releasing-projects-on-github/automatically-generated-release-notes